### PR TITLE
Add Responses API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # openai-api-samples
 Sample usage for OpenAI APIs
+
+## Responses API examples
+The `responses_api_examples.py` script shows how to:
+
+- send a basic prompt using the `responses` endpoint
+- retrieve a response by ID to demonstrate stateful behavior
+- continue a conversation by referencing `previous_response_id`
+- call the built-in `web_search` tool
+
+Run the script after setting `OPENAI_API_KEY` in your environment.

--- a/responses_api_examples.py
+++ b/responses_api_examples.py
@@ -1,0 +1,35 @@
+from openai import OpenAI
+import os
+
+# Initialize OpenAI client using the API key in the OPENAI_API_KEY environment variable
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+# ---- Basic Usage ----
+# Create a simple response asking the model to tell a joke
+basic_response = client.responses.create(
+    model="gpt-4o-mini",  # any supported model
+    input="tell me a joke",
+)
+print("Basic response:\n", basic_response.output[0].content[0].text)
+
+# Retrieve the response using its ID to show that the API stores state
+fetched = client.responses.retrieve(response_id=basic_response.id)
+print("Fetched response:\n", fetched.output[0].content[0].text)
+
+# ---- Continue Conversation ----
+# Continue from the previous response by specifying previous_response_id
+followup = client.responses.create(
+    model="gpt-4o-mini",
+    input="tell me another",
+    previous_response_id=basic_response.id,
+)
+print("Follow up response:\n", followup.output[0].content[0].text)
+
+# ---- Using Hosted Tools ----
+# Example that enables the built-in web search tool
+search_response = client.responses.create(
+    model="gpt-4o",  # or another supported model
+    input="What's the latest news about AI?",
+    tools=[{"type": "web_search"}],
+)
+print("Web search result:\n", search_response.output[0].content[0].text)


### PR DESCRIPTION
## Summary
- show how to use the new `responses` endpoint
- demonstrate retrieving the stateful response
- continue a conversation with `previous_response_id`
- show usage of the `web_search` tool

## Testing
- `python3 -m py_compile responses_api_examples.py`

------
https://chatgpt.com/codex/tasks/task_e_6868871637248331bdb243bf18cb3c47